### PR TITLE
Update FreeRTOS to SMP branch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ build
 *.user
 CMakeLists.txt.old
 pico-sdk
+.DS_Store

--- a/build-all.sh
+++ b/build-all.sh
@@ -5,7 +5,7 @@ cmake -S tools/SimpleFSBuilder -B tools/SimpleFSBuilder/build
 make -C tools/SimpleFSBuilder/build || exit 1
 
 test -d pico-sdk || git clone --recursive https://github.com/raspberrypi/pico-sdk
-test -d pico-sdk/FreeRTOS || git clone --recursive https://github.com/FreeRTOS/FreeRTOS-Kernel pico-sdk/FreeRTOS
+test -d pico-sdk/FreeRTOS || git clone --recursive --branch smp https://github.com/FreeRTOS/FreeRTOS-Kernel pico-sdk/FreeRTOS
 grep -e ip4_secondary_ip_address pico-sdk/lib/lwip/src/core/ipv4/ip4.c || patch -p1 -d pico-sdk/lib/lwip < lwip_patch/lwip.patch || (echo "Failed to apply patch" && exit 1)
 
 


### PR DESCRIPTION
I was receiving the error
````
#error configUSE_CORE_AFFINITY is not supported in single core FreeRTOS
````
which was resolved by using the `smp` branch.