### PR TITLE
build specifically with FreeRTOS 10.6.2

### DIFF
--- a/build-all.sh
+++ b/build-all.sh
@@ -5,7 +5,7 @@ cmake -S tools/SimpleFSBuilder -B tools/SimpleFSBuilder/build
 make -C tools/SimpleFSBuilder/build || exit 1
 
 test -d pico-sdk || git clone --recursive https://github.com/raspberrypi/pico-sdk
-test -d pico-sdk/FreeRTOS || git clone --recursive https://github.com/FreeRTOS/FreeRTOS-Kernel pico-sdk/FreeRTOS
+test -d pico-sdk/FreeRTOS || git clone --recursive --branch=V10.6.2 https://github.com/FreeRTOS/FreeRTOS-Kernel pico-sdk/FreeRTOS
 grep -e ip4_secondary_ip_address pico-sdk/lib/lwip/src/core/ipv4/ip4.c || patch -p1 -d pico-sdk/lib/lwip < lwip_patch/lwip.patch || (echo "Failed to apply patch" && exit 1)
 
 


### PR DESCRIPTION
Before this small change, the PicoHTTPServer project would try to build against the development version of FreeRTOS (the tip of the master branch).  At the current time this branch is in flux and PicoHTTPServer does not build.

This commit specifies the exact version of FreeRTOS to build against as 10.6.2 (the most recent stable version), which I've verified works.

A better solution might be to use FreeRTOS as a submodule, so that the PicoHTTPServer repo can explicitly control the FreeRTOS version, instead of relying on the build script to select one.