### PR TITLE
Fixes a crash when no zone is found

### DIFF
--- a/PicoHTTPServer/httpserver.c
+++ b/PicoHTTPServer/httpserver.c
@@ -376,6 +376,7 @@ http_server_instance http_server_create(const char *main_host, const char *main_
 	ctx->hostname = main_host;
 	ctx->domain_name = main_domain;
 	ctx->buffer_size = buffer_size;
+	ctx->first_zone = NULL;
 	
 	TaskHandle_t task;
 	xTaskCreate(http_server_thread, "HTTP Server", configMINIMAL_STACK_SIZE, ctx, tskIDLE_PRIORITY + 2, &task);


### PR DESCRIPTION
## Issue
The pull request fixes a bug when no zone was found by the http server. 

## Reason for the Bug
The `first_zone` variable was not explicitly initialized to `NULL` when the server started.

The program crashes when attempting to read uninitialized memory:
```c
for (http_zone *zone = ctx->server->first_zone; zone; zone = zone->next) {
```
The zones form a linked list, where the first zone (`zone->next`) is assigned to `server->first_zone`.
```c
void http_server_add_zone(http_server_instance server, http_zone *zone, const char *prefix, http_request_handler handler, void *context)
{
  zone->next = server->first_zone;
  zone->prefix = prefix;
  zone->prefix_len = strlen(prefix);
  zone->handler = handler;
  zone->context = context;
  server->first_zone = zone;
}
```
When looping in the for loop, depending on the compilator, the last pointer may not be NULL. (This was my case)


## Change and Improvement
### The Fix
The fix involved explicitly initializing `first_zone` to `NULL`.

Best regard,